### PR TITLE
Improve async pagination support

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,8 @@
 
 ### Other Changes
 * Optionally use `ultrajson` instead of stdlib `json`, if installed
+* Add `loop` argument to iNatClient and Paginator classes to allow passing an async event loop to be used for async iteration
+* Add `Paginator.async_all()` method (async, non-blocking version of `.all()`)
 
 ## 0.17.4 (2022-07-11)
 * Use a single data directory instead of separate 'cache' and 'user data' dirs

--- a/pyinaturalist/client.py
+++ b/pyinaturalist/client.py
@@ -1,5 +1,6 @@
 # TODO: "optional auth" option
 # TODO: Improve Sphinx docs generated for controller attributes
+from asyncio import AbstractEventLoop
 from inspect import ismethod
 from logging import getLogger
 from typing import Any, Callable, Dict, Type
@@ -92,6 +93,7 @@ class iNatClient:
             tokens as needed. Using a keyring instead is recommended, though.
         default_params: Default request parameters to pass to any applicable API requests
         dry_run: Just log all requests instead of sending real requests
+        loop: An event loop to use to run any executors used for async iteration
         session: Session object to use instead of creating a new one
         kwargs: Keyword arguments for :py:class:`.ClientSession`
     """
@@ -101,12 +103,14 @@ class iNatClient:
         creds: Dict[str, str] = None,
         default_params: Dict[str, Any] = None,
         dry_run: bool = False,
+        loop: AbstractEventLoop = None,
         session: Session = None,
         **kwargs,
     ):
         self.creds = creds or {}
         self.default_params = default_params or {}
         self.dry_run = dry_run
+        self.loop = loop
         self.session = session or ClientSession(**kwargs)
 
         self._access_token = None
@@ -162,7 +166,7 @@ class iNatClient:
             params: Original request parameters
         """
         kwargs = self.add_client_settings(request_function, kwargs, auth)
-        return cls(request_function, model, **kwargs)
+        return cls(request_function, model, loop=self.loop, **kwargs)
 
     def request(self, request_function: Callable, *args, auth: bool = False, **kwargs):
         """Send a request, with client settings applied.

--- a/pyinaturalist/controllers/observation_controller.py
+++ b/pyinaturalist/controllers/observation_controller.py
@@ -52,12 +52,12 @@ class ObservationController(BaseController):
 
     @document_controller_params(get_observations)
     def search(self, **params) -> Paginator[Observation]:
-        params = validate_multiple_choice_param(params, 'order_by', V1_OBS_ORDER_BY_PROPERTIES)
-        params = self.client.add_client_settings(get_observations, params)
-        # self.client.session.get(f'{API_V1}/observations', **params).json()
-        return Paginator(
-            self.client.session.get, Observation, f'{API_V1}/observations', method='id', **params
-        )
+        # Using a simplified version of v1.get_observations() to avoid duplicate conversions
+        def _get_observations(**params):
+            params = validate_multiple_choice_param(params, 'order_by', V1_OBS_ORDER_BY_PROPERTIES)
+            return self.client.session.get(f'{API_V1}/observations', **params).json()
+
+        return self.client.paginate(_get_observations, Observation, method='id', **params)
 
     # TODO: Does this need a model with utility functions, or is {datetime: count} sufficient?
     @document_controller_params(get_observation_histogram)

--- a/pyinaturalist/controllers/observation_controller.py
+++ b/pyinaturalist/controllers/observation_controller.py
@@ -17,7 +17,7 @@ from pyinaturalist.models import (
     TaxonSummary,
     UserCounts,
 )
-from pyinaturalist.paginator import Paginator
+from pyinaturalist.paginator import IDRangePaginator, Paginator
 from pyinaturalist.request_params import validate_multiple_choice_param
 from pyinaturalist.v1 import (
     create_observation,
@@ -57,7 +57,7 @@ class ObservationController(BaseController):
             params = validate_multiple_choice_param(params, 'order_by', V1_OBS_ORDER_BY_PROPERTIES)
             return self.client.session.get(f'{API_V1}/observations', **params).json()
 
-        return self.client.paginate(_get_observations, Observation, method='id', **params)
+        return self.client.paginate(_get_observations, Observation, cls=IDRangePaginator, **params)
 
     # TODO: Does this need a model with utility functions, or is {datetime: count} sufficient?
     @document_controller_params(get_observation_histogram)

--- a/pyinaturalist/controllers/user_controller.py
+++ b/pyinaturalist/controllers/user_controller.py
@@ -30,9 +30,10 @@ class UserController(BaseController):
         Args:
             user_ids: One or more project IDs
         """
-        return IDPaginator(get_user_by_id, User, ids=user_ids, **params)
+        return self.client.paginate(get_user_by_id, User, cls=IDPaginator, ids=user_ids, **params)
 
+    # TODO: Wrap in paginator?
     @document_controller_params(get_users_autocomplete)
     def autocomplete(self, **params) -> List[User]:
-        response = get_users_autocomplete(**params)
+        response = self.client.request(get_users_autocomplete, **params)
         return User.from_json_list(response)

--- a/pyinaturalist/paginator.py
+++ b/pyinaturalist/paginator.py
@@ -25,6 +25,7 @@ from pyinaturalist.constants import (
     REQUESTS_PER_MINUTE,
     IntOrStr,
     JsonResponse,
+    RequestParams,
     ResponseResult,
 )
 from pyinaturalist.models import T
@@ -43,9 +44,6 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
         per_page: Maximum number of results to fetch per page
         loop: An event loop to use to run any executors used for async iteration
         kwargs: Original request parameters
-
-
-
     """
 
     def __init__(
@@ -56,27 +54,25 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
         limit: int = None,
         per_page: int = None,
         loop: AbstractEventLoop = None,
-        **kwargs,
+        **request_kwargs,
     ):
-        self.kwargs = {k: v for k, v in kwargs.items() if v is not None}
         self.request_function = request_function
         self.request_args = request_args
-        self.loop = loop
-        self.model = model
-        self.total_limit = limit
-        self.per_page = per_page or PER_PAGE_RESULTS
+        self.request_kwargs = {k: v for k, v in request_kwargs.items() if v is not None}
+        self.request_kwargs.pop('page', None)
 
         self.exhausted = False
+        self.loop = loop
+        self.model = model
+        self.per_page = per_page or PER_PAGE_RESULTS
+        self.page = 1
         self.results_fetched = 0
+        self.total_limit = limit
         self.total_results: Optional[int] = None
-
-        # Set initial pagination params
-        self.kwargs.pop('per_page', None)
-        self.kwargs['page'] = 1
 
         if request_function:
             log_kwargs = {
-                k: v for k, v in self.kwargs.items() if k not in ['session', 'access_token']
+                k: v for k, v in self.request_kwargs.items() if k not in ['session', 'access_token']
             }
             logger.debug(
                 f'Prepared paginated request: {self.request_function.__name__}'
@@ -123,7 +119,7 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
             Either the total number of results, if the endpoint provides pagination info, or ``-1``
         """
         if self.total_results is None:
-            kwargs = {**self.kwargs, 'per_page': 0}
+            kwargs = {**self.request_kwargs, 'per_page': 0}
             response = self.request_function(*self.request_args, **kwargs)
             if isinstance(response, Response):
                 response = response.json()
@@ -144,7 +140,11 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
             self.per_page = self.total_limit - self.results_fetched
 
         # Fetch results; handle response object or dict
-        response = self.request_function(*self.request_args, **self.kwargs, per_page=self.per_page)
+        response = self.request_function(
+            *self.request_args,
+            **self.request_kwargs,
+            **self._get_pagination_kwargs(),
+        )
         if isinstance(response, Response):
             response = response.json()
         results = response.get('results', response)
@@ -152,35 +152,42 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
         # Note: For id-based pagination, only the first page's 'total_results' is accurate
         if self.total_results is None:
             self.total_results = response.get('total_results', len(results))
+        self.results_fetched += len(results)
 
         # If this is the first of multiple requests, log the estimated time and number of requests
-        self.results_fetched += len(results)
-        self._update_next_page_params(results)
-        if self.results_fetched == len(results) and not self.exhausted:
-            self._estimate()
+        if not self._check_exhausted(results):
+            if self.page == 1:
+                self._estimate()
+            self.page += 1
 
         return results
 
-    def _check_exhausted(self, page_results: List = None):
-        return (
-            (self.total_limit and self.results_fetched >= self.total_limit)
-            or (self.total_results and self.results_fetched >= self.total_results)
-            or (self.per_page and page_results is not None and len(page_results) < self.per_page)
+    # The following two methods may be overridden by subclasses for different pagination methods
+    def _get_pagination_kwargs(self) -> RequestParams:
+        """Get any extra request parameters needed for pagination"""
+        return {'page': self.page, 'per_page': self.per_page}
+
+    def _check_exhausted(self, page_results: List = None) -> bool:
+        """Check all conditions that indicate no more results are available.
+        (relevant conditions and error cases vary by API endpoint)
+        """
+        n_results = len(page_results or [])
+        self.exhausted = any(
+            [
+                self.exhausted,
+                (self.total_limit and self.results_fetched >= self.total_limit),
+                (self.total_results and self.results_fetched >= self.total_results),
+                (self.per_page and n_results < self.per_page),
+                n_results == 0,
+            ]
         )
+        return self.exhausted
 
     def _deduplicate(self, results) -> List[T]:
         """Deduplicate results by ID"""
         unique_results = {result.id: result for result in results}
         self.total_results = len(unique_results)
         return list(unique_results.values())
-
-    def _update_next_page_params(self, page_results):
-        """Set params for next request, if there are more results. Also check page size, in case
-        total_results is off due to race condition, outdated index, etc.
-        """
-        if self._check_exhausted(page_results):
-            self.exhausted = True
-        self.kwargs['page'] += 1
 
     def _estimate(self):
         """Log the estimated total number of requests and rate-limiting delay, and show a warning if
@@ -220,15 +227,22 @@ class IDRangePaginator(Paginator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.kwargs['order_by'] = 'id'
-        self.kwargs['order'] = 'asc'
-        self.kwargs.pop('page', None)
+        self.id_above: Optional[int] = None
 
-    def _update_next_page_params(self, page_results):
-        """Set params for next request, if there are more results"""
-        if self._check_exhausted(page_results):
-            self.exhausted = True
-        self.kwargs['id_above'] = page_results[-1]['id']
+    def _get_pagination_kwargs(self):
+        return {
+            'id_above': self.id_above,
+            'per_page': self.per_page,
+            'order_by': 'id',
+            'order': 'asc',
+        }
+
+    def _next_page(self) -> List[ResponseResult]:
+        # Update params for next request, if there are more results
+        results = super()._next_page()
+        if not self.exhausted:
+            self.id_above = results[-1]['id']
+        return results
 
 
 class IDPaginator(Paginator):
@@ -239,7 +253,7 @@ class IDPaginator(Paginator):
         if ids_per_request == 1:
             self.id_batches = deque(ids or [])
         else:
-            self.id_batches = deque(list(chunkify(ids, ids_per_request)))  # type: ignore
+            self.id_batches = deque(list(_chunkify(ids, ids_per_request)))  # type: ignore
         self.total_results = len(ids)  # type: ignore
 
     def _next_page(self) -> List[ResponseResult]:
@@ -250,11 +264,21 @@ class IDPaginator(Paginator):
             self.exhausted = True
             return []
 
-        response = self.request_function(next_ids, *self.request_args, **self.kwargs)
+        response = self.request_function(next_ids, *self.request_args, **self.request_kwargs)
         if isinstance(response, Response):
             response = response.json()
-        self.results_fetched += 1
-        return response['results'] if 'results' in response else [response]
+
+        results = response['results'] if 'results' in response else [response]
+        self.page += 1
+        self.results_fetched += len(results)
+        return results
+
+
+def _chunkify(iterable: Iterable, max_size: int) -> Iterator[List]:
+    """Split an iterable into chunks of a max size"""
+    iterable = list(iterable)
+    for index in range(0, len(iterable), max_size):
+        yield iterable[index : index + max_size]
 
 
 class AutocompletePaginator(Paginator):
@@ -272,24 +296,26 @@ class AutocompletePaginator(Paginator):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.kwargs.pop('page', None)
-        self.kwargs.pop('order_by', None)
+        self.request_kwargs.pop('order_by', None)
 
     def all(self) -> List[T]:
         """Get all results in a single de-duplicated list"""
         return self._deduplicate(list(self))
 
-    def _update_next_page_params(self, page_results):
-        """After the first request, update the order_by param. After the second request, we're done."""
-        if (
-            self._check_exhausted()
-            or (self.per_page and self.results_fetched > self.per_page)
-            or (self.per_page and len(page_results) < self.per_page)
-            or len(page_results) == 0
-        ):
-            self.exhausted = True
-        else:
-            self.kwargs['order_by'] = 'area'
+    def _check_exhausted(self, page_results: List = None):
+        """Also check for the odd case in which we get more results than requested"""
+        self.exhausted = any(
+            [
+                super()._check_exhausted(page_results),
+                (self.per_page and self.results_fetched > self.per_page),
+            ]
+        )
+
+    def _get_pagination_kwargs(self):
+        kwargs = super()._get_pagination_kwargs()
+        if not self.exhausted and self.page >= 1:
+            kwargs['order_by'] = 'area'
+        return kwargs
 
 
 if TYPE_CHECKING:
@@ -337,6 +363,16 @@ class JsonIDRangePaginator(JsonPaginatorMixin, IDRangePaginator):
     pass
 
 
+def paginate_all(request_function: Callable, *args, method: str = 'page', **kwargs) -> JsonResponse:
+    """Get all pages of a multi-page request. Explicit pagination parameters will be overridden.
+
+    Returns:
+        Response dict containing combined results, in the same format as ``api_func``
+    """
+    paginator = JsonIDRangePaginator if method == 'id' else JsonPaginator
+    return paginator(request_function, *args, **kwargs).all()
+
+
 class WrapperPaginator(Paginator):
     """Paginator class that wraps results that have already been fetched."""
 
@@ -351,20 +387,3 @@ class WrapperPaginator(Paginator):
     def next_page(self):
         self.exhausted = True
         return self.results
-
-
-def chunkify(iterable: Iterable, max_size: int) -> Iterator[List]:
-    """Split an iterable into chunks of a max size"""
-    iterable = list(iterable)
-    for index in range(0, len(iterable), max_size):
-        yield iterable[index : index + max_size]
-
-
-def paginate_all(request_function: Callable, *args, method: str = 'page', **kwargs) -> JsonResponse:
-    """Get all pages of a multi-page request. Explicit pagination parameters will be overridden.
-
-    Returns:
-        Response dict containing combined results, in the same format as ``api_func``
-    """
-    paginator = JsonIDRangePaginator if method == 'id' else JsonPaginator
-    return paginator(request_function, *args, **kwargs).all()

--- a/pyinaturalist/paginator.py
+++ b/pyinaturalist/paginator.py
@@ -97,6 +97,10 @@ class Paginator(Iterable, AsyncIterable, Generic[T]):
             for result in self.next_page():
                 yield result
 
+    async def async_all(self) -> List[T]:  # Better name TBD?
+        """Get all results in a single list (non-blocking)"""
+        return [result async for result in self]
+
     def all(self) -> List[T]:
         """Get all results in a single list"""
         return list(self)

--- a/test/test_paginator.py
+++ b/test/test_paginator.py
@@ -24,9 +24,10 @@ def test_iter(requests_mock):
         ],
     )
 
-    # 4 Pages could be returned, but only 3 should be requested
+    # Only 3 pages should be requested
     paginator = Paginator(get_observations, Observation, id=[57754375, 57707611], per_page=1)
     observations = list(paginator)
+    assert paginator.page == 3
     assert len(observations) == 3
 
 
@@ -42,6 +43,7 @@ def test_iter__with_limit(requests_mock):
     paginator = Paginator(get_observations, Observation, id=[57754375, 57707611], limit=1)
     observations = list(paginator)
     assert len(observations) == 1
+    assert paginator.page == 1
 
 
 @pytest.mark.asyncio
@@ -62,27 +64,6 @@ async def test_async_iter(requests_mock):
         page='all',
     )
     observations = [obs async for obs in paginator]
-    assert len(observations) == 2
-
-
-@pytest.mark.asyncio
-async def test_async_all(requests_mock):
-    requests_mock.get(
-        f'{API_V1}/observations',
-        [
-            {'json': SAMPLE_DATA['get_observations_node_page1'], 'status_code': 200},
-            {'json': SAMPLE_DATA['get_observations_node_page2'], 'status_code': 200},
-        ],
-    )
-
-    paginator = Paginator(
-        get_observations,
-        Observation,
-        id=[57754375, 57707611],
-        per_page=1,
-        page='all',
-    )
-    observations = await paginator.async_all()
     assert len(observations) == 2
 
 
@@ -109,6 +90,27 @@ async def test_async_iter__custom_loop(mock_get_running_loop, requests_mock):
     observations = [obs async for obs in paginator]
     assert len(observations) == 2
     mock_get_running_loop.run_in_executor.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_async_all(requests_mock):
+    requests_mock.get(
+        f'{API_V1}/observations',
+        [
+            {'json': SAMPLE_DATA['get_observations_node_page1'], 'status_code': 200},
+            {'json': SAMPLE_DATA['get_observations_node_page2'], 'status_code': 200},
+        ],
+    )
+
+    paginator = Paginator(
+        get_observations,
+        Observation,
+        id=[57754375, 57707611],
+        per_page=1,
+        page='all',
+    )
+    observations = await paginator.async_all()
+    assert len(observations) == 2
 
 
 def test_count(requests_mock):

--- a/test/test_paginator.py
+++ b/test/test_paginator.py
@@ -66,6 +66,27 @@ async def test_async_iter(requests_mock):
 
 
 @pytest.mark.asyncio
+async def test_async_all(requests_mock):
+    requests_mock.get(
+        f'{API_V1}/observations',
+        [
+            {'json': SAMPLE_DATA['get_observations_node_page1'], 'status_code': 200},
+            {'json': SAMPLE_DATA['get_observations_node_page2'], 'status_code': 200},
+        ],
+    )
+
+    paginator = Paginator(
+        get_observations,
+        Observation,
+        id=[57754375, 57707611],
+        per_page=1,
+        page='all',
+    )
+    observations = await paginator.async_all()
+    assert len(observations) == 2
+
+
+@pytest.mark.asyncio
 @patch('pyinaturalist.paginator.get_running_loop')
 async def test_async_iter__custom_loop(mock_get_running_loop, requests_mock):
     """If an async event loop is specified, make sure that is used instead of the default loop"""


### PR DESCRIPTION
Closes #423 

* Add support for passing an async event loop to run executor for async pagination
    * Can be used via `loop` param for either `iNatClient` or `Paginator`
* Add a `Paginator.async_all()` method
* Add a separate paginator class for ID range-based pagination instead of toggling with 'method' param
* Add client settings in remaining controller methods that were missing them
