### PR TITLE
Add full list of rank levels

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -34,6 +34,7 @@
 * Add `urls_expire_after` option to `ClientSession` to update default cache expiration URL patterns
 
 ### Other Changes
+* All API functions that accept taxonomic rank parameters (`rank`, `lrank`, `observation_hrank`,etc.) now accept all rank variations that iNaturalist accepts (`var`, `spp` `sub-species`, etc.)
 * Fix `ObservationFieldValue` conversions for `date` and `datetime` fields
 * Fix printing `Annotation` objects with `rich`
 * Optionally use `ultrajson` instead of stdlib `json`, if installed

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -106,35 +106,47 @@ ICONIC_EMOJI = {
 }
 ROOT_TAXON_ID = 48460
 
-# Taxonomic ranks that can be filtered on
-RANKS = [
-    'form',
-    'variety',
-    'subspecies',
-    'hybrid',
-    'species',
-    'genushybrid',
-    'subgenus',
-    'genus',
-    'subtribe',
-    'tribe',
-    'supertribe',
-    'subfamily',
-    'family',
-    'epifamily',
-    'superfamily',
-    'infraorder',
-    'suborder',
-    'order',
-    'superorder',
-    'infraclass',
-    'subclass',
-    'class',
-    'superclass',
-    'subphylum',
-    'phylum',
-    'kingdom',
-]
+# Taxonomic ranks that can be filtered on, and numeric values for comparison
+# Source: https://github.com/inaturalist/inaturalist/blob/main/app/models/taxon.rb
+RANK_LEVELS = {
+    'infrahybrid': 5,
+    'form': 5,
+    'variety': 5,
+    'subspecies': 5,
+    'hybrid': 10,
+    'species': 10,
+    'complex': 11,
+    'subsection': 12,
+    'section': 13,
+    'subgenus': 15,
+    'genushybrid': 20,
+    'genus': 20,
+    'subtribe': 24,
+    'tribe': 25,
+    'supertribe': 26,
+    'subfamily': 27,
+    'family': 30,
+    'epifamily': 32,
+    'superfamily': 33,
+    'zoosubsection': 33.5,
+    'zoosection': 34,
+    'parvorder': 34.5,
+    'infraorder': 35,
+    'suborder': 37,
+    'order': 40,
+    'superorder': 43,
+    'subterclass': 44,
+    'infraclass': 45,
+    'subclass': 47,
+    'class': 50,
+    'superclass': 53,
+    'subphylum': 57,
+    'phylum': 60,
+    'kingdom': 70,
+    'unranked': 90,  # Invented to make parent check work (this is null in the db)
+    'stateofmatter': 100,
+}
+RANKS = list(RANK_LEVELS.keys())
 
 # Simplified subset of ranks that are useful for display
 COMMON_RANKS = [
@@ -149,6 +161,20 @@ COMMON_RANKS = [
     'phylum',
     'kingdom',
 ]
+
+# Additional equivalents that iNat accepts
+RANK_EQUIVALENTS = {
+    'division': 'phylum',
+    'gen': 'genus',
+    'sp': 'species',
+    'spp': 'species',
+    'infraspecies': 'subspecies',
+    'ssp': 'subspecies',
+    'subsp': 'subspecies',
+    'trinomial': 'subspecies',
+    'var': 'variety',
+}
+
 
 # Options for multiple choice parameters (non-endpoint-specific)
 CC_LICENSES = ['CC-BY', 'CC-BY-NC', 'CC-BY-ND', 'CC-BY-SA', 'CC-BY-NC-ND', 'CC-BY-NC-SA', 'CC0']
@@ -177,6 +203,7 @@ V1_OBS_ORDER_BY_PROPERTIES = ['created_at', 'id', 'observed_on', 'species_guess'
 PROJECT_ORDER_BY_PROPERTIES = ['created', 'distance', 'featured', 'recent_posts', 'updated']
 
 # Multiple-choice request parameters, with keys mapped to their possible choices (non-endpoint-specific)
+# TODO: python 3.11 supports Literal[*list] syntax, which would be useful here
 MULTIPLE_CHOICE_PARAMS = {
     'box': INBOXES,
     'category': ID_CATEGORIES,

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -146,7 +146,7 @@ RANK_LEVELS = {
     'unranked': 90,  # Invented to make parent check work (this is null in the db)
     'stateofmatter': 100,
 }
-RANKS = list(RANK_LEVELS.keys())
+RANKS = list(RANK_LEVELS.keys())[:-2]
 
 # Simplified subset of ranks that are useful for display
 COMMON_RANKS = [
@@ -162,7 +162,7 @@ COMMON_RANKS = [
     'kingdom',
 ]
 
-# Additional equivalents that iNat accepts
+# Additional equivalents that iNat accepts; see request_params.normalize_rank() for more variations
 RANK_EQUIVALENTS = {
     'division': 'phylum',
     'gen': 'genus',

--- a/test/v1/test_taxa.py
+++ b/test/v1/test_taxa.py
@@ -8,7 +8,7 @@ from pyinaturalist.v1 import get_taxa, get_taxa_autocomplete, get_taxa_by_id, ge
 from test.conftest import load_sample_data
 
 CLASS_AND_HIGHER = ['class', 'superclass', 'subphylum', 'phylum', 'kingdom']
-SPECIES_AND_LOWER = ['form', 'variety', 'subspecies', 'hybrid', 'species']
+SPECIES_AND_LOWER = ['infrahybrid', 'form', 'variety', 'subspecies', 'hybrid', 'species']
 CLASS_THOUGH_PHYLUM = ['class', 'superclass', 'subphylum', 'phylum']
 
 


### PR DESCRIPTION
* Add some ranks that were missing
* Add numeric rank levels
* Add aliases/equivalent ranks that iNaturalist accepts
* Normalize some other rank variations for all endpoints that take a rank parameter: casing, hyphenation, and unique prefixes

Example:
```python
>>> from pyinaturalist.request_params import normalize_rank
>>> normalize_rank('ssp.')
'subspecies'
>>> normalize_rank('Sub-Species')
'subspecies'
```