### PR TITLE
Add property to calculate cumulative community IDs

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@ Add support for searching observations by observation fields, using a new `obser
 * `get_observation_species_counts()`
 
 ### Models
+* Add `Observation.ident_taxon_ids` dynamic property to get all identification taxon IDs (with ancestors)
 * Add `Sound` model for `Observation.sounds`
 * Fix initialization of `ListedTaxon.place`
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -16,6 +16,7 @@ Add support for searching observations by observation fields, using a new `obser
 
 ### Models
 * Add `Observation.ident_taxon_ids` dynamic property to get all identification taxon IDs (with ancestors)
+* Add `Observation.cumulative_ids` dynamic property to calculate agreements/total community identifications
 * Add `Sound` model for `Observation.sounds`
 * Fix initialization of `ListedTaxon.place`
 

--- a/pyinaturalist/docs/model_docs.py
+++ b/pyinaturalist/docs/model_docs.py
@@ -14,7 +14,7 @@ from sphinx_autodoc_typehints import format_annotation
 from pyinaturalist.constants import DOCS_DIR
 from pyinaturalist.models import LazyProperty, get_lazy_properties
 
-IGNORE_PROPERTIES = ['row']
+IGNORE_PROPERTIES = ['_row', '_str_attrs']
 MODEL_DOC_DIR = join(DOCS_DIR, 'models')
 
 

--- a/pyinaturalist/models/observation.py
+++ b/pyinaturalist/models/observation.py
@@ -206,9 +206,11 @@ class Observation(BaseModel):
         observed_on = kwargs.pop('time_observed_at', None)
         if not isinstance(kwargs['observed_on'], datetime) and observed_on:
             kwargs['observed_on'] = observed_on
+
         # Set default URL based on observation ID
         if not kwargs.get('uri'):
             kwargs['uri'] = f'{INAT_BASE_URL}/observations/{kwargs.get("id", "")}'
+
         # Set identifications_count if missing
         if kwargs.get('identifications') and not kwargs.get('identifications_count'):
             kwargs['identifications_count'] = len(kwargs['identifications'])
@@ -216,9 +218,14 @@ class Observation(BaseModel):
 
     @classmethod
     def from_id(cls, id: int):
-        """Lookup and create a new Observation object from an ID"""
+        """**[Deprecated]** Lookup and create a new Observation object from an ID"""
         from pyinaturalist.v1 import get_observation
 
+        warn(
+            DeprecationWarning(
+                'This method is deprecated; please use iNatClient.observations() instead'
+            )
+        )
         json = get_observation(id)
         return cls.from_json(json)
 

--- a/pyinaturalist/models/observation.py
+++ b/pyinaturalist/models/observation.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from itertools import chain
 from typing import Any, Dict, List
 
 from pyinaturalist.constants import (
@@ -229,6 +230,13 @@ class Observation(BaseModel):
             return self.taxon.icon
         else:
             return IconPhoto.from_iconic_taxon('unknown')
+
+    @property
+    def ident_taxon_ids(self) -> List[int]:
+        """Get all taxon IDs (including ancestors) from identifications"""
+        ident_taxa = [ident.taxon for ident in self.identifications if ident.taxon]
+        ident_ids = chain.from_iterable([t.ancestor_ids + [t.id] for t in ident_taxa])
+        return list(set(ident_ids))
 
     @property
     def _row(self) -> TableRow:

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -224,10 +224,9 @@ class Taxon(BaseModel):
         """Info URL on iNaturalist.org"""
         return f'{INAT_BASE_URL}/taxa/{self.id}'
 
-    # TODO: Experimental; not sure if I want to have API calls in model classes
     @classmethod
     def from_id(cls, id: int) -> 'Taxon':
-        """Lookup and create a new Taxon object by ID"""
+        """**[Deprecated]** Lookup and create a new Taxon object by ID"""
         from pyinaturalist.v1 import get_taxa_by_id
 
         warn(DeprecationWarning('This method is deprecated; please use iNatClient.taxa() instead'))

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -488,6 +488,37 @@ def test_observation__ident_taxon_ids():
     ]
 
 
+def test_observation__ccumulative_ids__all_agree():
+    obs = Observation.from_json(j_observation_2)
+    assert obs.cumulative_ids == (2, 2)
+
+
+def test_observation__cumulative_ids__most_agree():
+    obs = Observation.from_json(j_observation_2)
+
+    # Add a dissenting ID from a different family
+    tiger_swallowtail = Taxon(
+        id=60551,
+        ancestor_ids=[
+            48460,
+            1,
+            47120,
+            372739,
+            47158,
+            184884,
+            47157,
+            47224,
+            47223,
+            49973,
+            207785,
+            47225,
+            545186,
+        ],
+    )
+    obs.identifications.append(Identification(taxon=tiger_swallowtail, current=True))
+    assert obs.cumulative_ids == (2, 3)
+
+
 def test_observations():
     obs_list = Observations.from_json_list(
         [j_observation_1, j_observation_1, j_observation_2, j_observation_3_ofvs]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -468,6 +468,26 @@ def test_observation__missing_default_photo_and_taxon():
     assert obs.default_photo.original_url.endswith('unknown-200px.png')
 
 
+def test_observation__ident_taxon_ids():
+    obs = Observation.from_json(j_observation_2)
+    assert obs.ident_taxon_ids == [
+        1,
+        372739,
+        48663,
+        48460,
+        47120,
+        47922,
+        184884,
+        47157,
+        47158,
+        522900,
+        47224,
+        134169,
+        48662,
+        61244,
+    ]
+
+
 def test_observations():
     obs_list = Observations.from_json_list(
         [j_observation_1, j_observation_1, j_observation_2, j_observation_3_ofvs]


### PR DESCRIPTION
Closes #479

Adds:
* `Observation.cumulative_ids`  (agreements, total)
* `Observation.ident_taxon_ids` (all identification taxon IDs, including ancestors)
  * This is a property that gets the IDs from `Observation.identifications`, so it will work for sources other than the API

Thanks to @synrg for providing reference info in #479!