### PR TITLE
Improvements for taxonomy trees and formatting

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,9 +15,9 @@ Add support for searching observations by observation fields, using a new `obser
 * `get_observation_species_counts()`
 
 ### Models
-* Add `LifeList.tree()` method to return a nested tree of taxa in a user's life list
-* Add `Taxon.flatten()` method to return a taxon and its descendants as a flat list
+* Add `make_tree()` function to build a tree from `Taxon` objects or a `LifeList`
 * Add `pprint_tree()` function to print a taxon tree on the console
+* Add `Taxon.flatten()` method to return a taxon and its descendants as a flat list
 * Add `Observation.ident_taxon_ids` dynamic property to get all identification taxon IDs (with ancestors)
 * Add `Observation.cumulative_ids` dynamic property to calculate agreements/total community identifications
 * Add `Sound` model for `Observation.sounds`

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -145,13 +145,10 @@ RANK_LEVELS = {
 }
 RANKS = list(RANK_LEVELS.keys())[:-2]
 
-# Simplified subset of ranks that are useful for display
+# The main 7 taxonomic ranks, used for condensed display
 COMMON_RANKS = [
-    'form',
-    'variety',
     'species',
     'genus',
-    'tribe',
     'family',
     'order',
     'class',

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -11,6 +11,7 @@ API_V0 = 'https://www.inaturalist.org'
 API_V1 = 'https://api.inaturalist.org/v1'
 API_V2 = 'https://api.inaturalist.org/v2'
 EXPORT_URL = 'https://www.inaturalist.org/observations/export'
+GBIF_TAXON_BASE_URL = 'https://www.gbif.org/species'
 INAT_BASE_URL = API_V0
 INAT_REPO = 'https://raw.githubusercontent.com/inaturalist/inaturalist/main'
 ICONIC_TAXA_BASE_URL = f'{INAT_REPO}/app/assets/images/iconic_taxa'

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -103,6 +103,7 @@ ROOT_TAXON_ID = 48460
 
 # Taxonomic ranks that can be filtered on, and numeric values for comparison
 # Source: https://github.com/inaturalist/inaturalist/blob/main/app/models/taxon.rb
+UNRANKED = 90  # Used for comparing unranked taxa
 RANK_LEVELS = {
     'infrahybrid': 5,
     'form': 5,
@@ -138,7 +139,7 @@ RANK_LEVELS = {
     'subphylum': 57,
     'phylum': 60,
     'kingdom': 70,
-    'unranked': 90,  # Invented to make parent check work (this is null in the db)
+    'unranked': UNRANKED,
     'stateofmatter': 100,
 }
 RANKS = list(RANK_LEVELS.keys())[:-2]

--- a/pyinaturalist/formatters.py
+++ b/pyinaturalist/formatters.py
@@ -249,8 +249,8 @@ def format_response(response: Response) -> str:
 
 
 def format_tree(taxon: Taxon, **kwargs) -> Tree:
-    """Format a a taxon and its descendants as a tree"""
-    node = Tree(f'{taxon.rank.title()} [i]{taxon.name}[/i]', **kwargs)
+    """Format a taxon and its descendants as a tree"""
+    node = Tree(f'{taxon.rich_full_name}', **kwargs)
     for child in taxon.children:
         node.add(format_tree(child))
     return node

--- a/pyinaturalist/models/identification.py
+++ b/pyinaturalist/models/identification.py
@@ -99,7 +99,7 @@ class Identification(Comment):
         return {
             'ID': self.id,
             'Taxon ID': self.taxon.id,
-            'Taxon': f'{self.taxon.emoji} {self.taxon.full_name}',
+            'Taxon': f'{self.taxon.emoji} {self.taxon.rich_full_name}',
             'User': self.user.login,
             'Category': self.category.title(),
             'From CV': self.vision,

--- a/pyinaturalist/models/observation.py
+++ b/pyinaturalist/models/observation.py
@@ -263,7 +263,7 @@ class Observation(BaseModel):
         return {
             'ID': self.id,
             'Taxon ID': self.taxon.id if self.taxon else None,
-            'Taxon': self.taxon.full_name if self.taxon else None,
+            'Taxon': self.taxon.rich_full_name if self.taxon else None,
             'Observed on': self.observed_on,
             'User': self.user.login,
             'Location': self.place_guess or self.location,

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -199,7 +199,11 @@ class Taxon(BaseModel):
         if not self.name:
             return f'{self.rank} {self.id}'
 
-        rank = f'{self.rank.title()} ' if self.rank else ''
+        rank = (
+            f'{self.rank.title()} '
+            if self.rank and self.rank_level > RANK_LEVELS['species']
+            else ''
+        )
         common_name = (
             f' ({title(self.preferred_common_name)})' if self.preferred_common_name else ''
         )

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -194,6 +194,14 @@ class Taxon(BaseModel):
     @property
     def full_name(self) -> str:
         """Taxon rank, scientific name, and common name (if available)"""
+        return self._full_name()
+
+    @property
+    def rich_full_name(self) -> str:
+        """Taxon full name, with italicized scientific name depending on rank (genus and below)"""
+        return self._full_name(markup=True)
+
+    def _full_name(self, markup: bool = False) -> str:
         if not self.name and not self.rank:
             return str(self.id)
         if not self.name:
@@ -204,10 +212,15 @@ class Taxon(BaseModel):
             if self.rank and self.rank_level > RANK_LEVELS['species']
             else ''
         )
+        name = (
+            f'[i]{self.name}[/i]'
+            if markup and self.rank_level <= RANK_LEVELS['genus']
+            else self.name
+        )
         common_name = (
             f' ({title(self.preferred_common_name)})' if self.preferred_common_name else ''
         )
-        return f'{rank}{self.name}{common_name}'
+        return f'{rank}{name}{common_name}'
 
     @property
     def icon(self) -> IconPhoto:

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -259,9 +259,12 @@ class Taxon(BaseModel):
     def flatten(self) -> List['Taxon']:
         """Return this taxon and all its descendants as a flat list"""
 
-        def flatten_tree(taxon: Taxon) -> List[Taxon]:
+        def flatten_tree(taxon: Taxon, ancestors=None) -> List[Taxon]:
+            taxon.ancestors = ancestors or []
             return [taxon] + list(
-                chain.from_iterable(flatten_tree(child) for child in taxon.children)
+                chain.from_iterable(
+                    flatten_tree(child, taxon.ancestors + [taxon]) for child in taxon.children
+                )
             )
 
         return flatten_tree(self)

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -379,20 +379,6 @@ class LifeList(BaseModelCollection):
             return self.count_without_taxon
         return super().get_count(taxon_id, count_field=count_field)
 
-    def tree(
-        self,
-        sort_key: Optional[TaxonSortKey] = None,
-        include_ranks: Optional[List[str]] = None,
-    ) -> Taxon:
-        """**Experimental**
-
-        Organize this life list into a taxonomic tree
-
-        Returns:
-            Root taxon of the tree
-        """
-        return make_tree(self.data, sort_key=sort_key, include_ranks=include_ranks)
-
 
 def _sort_rank_name(taxon):
     """Get a sort key by rank (descending) and name"""

--- a/pyinaturalist/models/taxon.py
+++ b/pyinaturalist/models/taxon.py
@@ -256,12 +256,19 @@ class Taxon(BaseModel):
         """Info URL on iNaturalist.org"""
         return f'{INAT_BASE_URL}/taxa/{self.id}'
 
-    def flatten(self) -> List['Taxon']:
-        """Return this taxon and all its descendants as a flat list"""
+    def flatten(self, include_ranks: Optional[List[str]] = None) -> List['Taxon']:
+        """Return this taxon and all its descendants as a flat list.
+
+        Args:
+            include_ranks: If provided, only include taxa with these ranks
+        """
 
         def flatten_tree(taxon: Taxon, ancestors=None) -> List[Taxon]:
+            # If this rank isn't included, skip to this taxon's children
+            current_level = [taxon] if not include_ranks or taxon.rank in include_ranks else []
             taxon.ancestors = ancestors or []
-            return [taxon] + list(
+
+            return current_level + list(
                 chain.from_iterable(
                     flatten_tree(child, taxon.ancestors + [taxon]) for child in taxon.children
                 )

--- a/test/controllers/test_observation_controller.py
+++ b/test/controllers/test_observation_controller.py
@@ -189,49 +189,6 @@ def test_life_list(requests_mock):
     assert bombus.descendant_obs_count == results.get_count(52775) == 154
 
 
-# TODO: This could be moved to model tests once tree features are finalized
-def test_life_list_tree(requests_mock):
-    requests_mock.get(
-        f'{API_V1}/observations/taxonomy',
-        json=j_life_list_2,
-        status_code=200,
-    )
-    client = iNatClient()
-    life_list = client.observations.life_list(user_id=545640, taxon_id=52775)
-
-    root = life_list.tree()
-
-    # Spot check the first few levels
-    assert root.name == 'Life'
-    assert root.children[0].name == 'Animalia'
-    assert root.children[0].children[0].name == 'Arthropoda'
-
-    # Ensure correct child sort order
-    node = root
-    for _ in range(14):
-        node = node.children[0]
-    assert node.name == 'Bombus'
-    children = [t.name for t in node.children]
-    assert children == ['Bombus', 'Psithyrus', 'Pyrobombus', 'Subterraneobombus', 'Thoracobombus']
-
-    # Ensure total taxon count is the same
-    assert len(root.flatten()) == len(life_list)
-
-
-def test_life_list_tree__invalid(requests_mock):
-    """Attempting to make a tree with no common root taxon should raise an error"""
-    requests_mock.get(
-        f'{API_V1}/observations/taxonomy',
-        json=SAMPLE_DATA['get_observations_node_page1'],
-        status_code=200,
-    )
-    client = iNatClient()
-    life_list = client.observations.life_list()
-
-    with pytest.raises(ValueError):
-        life_list.tree()
-
-
 def test_popular_fields(requests_mock):
     requests_mock.get(
         f'{API_V1}/observations/popular_field_values',

--- a/test/test_formatters.py
+++ b/test/test_formatters.py
@@ -170,7 +170,7 @@ Stateofmatter Life
 """
 
 
-@pytest.mark.parametrize('taxa', [life_list, life_list.tree(), life_list.data])
+@pytest.mark.parametrize('taxa', [life_list, make_tree(life_list), life_list.data])
 def test_pprint_tree(taxa):
     """Test pprint_tree() with a single taxon (tree), a LifeList, and a regular list of taxa"""
 

--- a/test/test_formatters.py
+++ b/test/test_formatters.py
@@ -121,9 +121,9 @@ Observation(
         Comment(id=2071611, username='borisb', created_at='Sep 05, 2018', truncated_body='suspect L. bardanae - but sits on Solanum (non-...')
     ],
     identifications=[
-        Identification(id=34896306, username='niconoe', taxon_name='Genus: Lixus', created_at='Sep 05, 2018', truncated_body=''),
-        Identification(id=34926789, username='borisb', taxon_name='Species: Lixus bardanae', created_at='Sep 05, 2018', truncated_body=''),
-        Identification(id=36039221, username='jpreudhomme', taxon_name='Species: Lixus bardanae', created_at='Sep 22, 2018', truncated_body='')
+        Identification(id=34896306, username='niconoe', taxon_name='Genus Lixus', created_at='Sep 05, 2018', truncated_body=''),
+        Identification(id=34926789, username='borisb', taxon_name='Lixus bardanae', created_at='Sep 05, 2018', truncated_body=''),
+        Identification(id=36039221, username='jpreudhomme', taxon_name='Lixus bardanae', created_at='Sep 22, 2018', truncated_body='')
     ],
     ofvs=[],
     photos=[
@@ -132,7 +132,7 @@ Observation(
     ],
     project_observations=[],
     sounds=[],
-    taxon=Taxon(id=493595, full_name='Species: Lixus bardanae'),
+    taxon=Taxon(id=493595, full_name='Lixus bardanae'),
     user=User(id=886482, login='niconoe', name='Nicolas Noé')
 )
 """
@@ -164,9 +164,9 @@ Stateofmatter Life
             └── Order Galliformes
                 └── Family Phasianidae
                     ├── Genus Bonasa
-                    │   └── Species Bonasa umbellus
+                    │   └── Bonasa umbellus
                     └── Genus Phasianus
-                        └── Species Phasianus colchicus
+                        └── Phasianus colchicus
 """
 
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -23,6 +23,7 @@ from pyinaturalist.constants import (
     PHOTO_CC_BASE_URL,
     PHOTO_INFO_BASE_URL,
     PHOTO_SIZES,
+    UNRANKED,
 )
 from pyinaturalist.models import *
 from test.conftest import sample_data_path
@@ -826,7 +827,7 @@ def test_taxon__ancestors_children():
     parent = taxon.ancestors[0]
     child = taxon.children[0]
     assert isinstance(parent, Taxon) and parent.id == 1
-    assert isinstance(child, Taxon) and child.id == 70116
+    assert isinstance(child, Taxon) and child.id == 70115
 
 
 def test_taxon__ancestor_ids():
@@ -910,7 +911,7 @@ def test_listed_taxon__id_wrapper_properties():
 def test_taxon__properties():
     taxon = Taxon.from_json(j_taxon_1)
     assert taxon.url == f'{INAT_BASE_URL}/taxa/70118'
-    assert taxon.child_ids == [70116, 70114, 70117, 70115]
+    assert taxon.child_ids == [70115, 70114, 70117, 70116]
     assert isinstance(taxon.parent, Taxon) and taxon.parent.id == 53850
 
 
@@ -944,7 +945,16 @@ def test_taxon__no_default_photo(taxon_id):
 def test_taxon__normalize_rank():
     taxon = Taxon(rank='spp')
     assert taxon.rank == 'species'
+
+
+def test_taxon__rank_level():
+    # If missing, level should be looked up by name, if available
+    taxon = Taxon(rank='species')
     assert taxon.rank_level == 10
+
+    # Otherwise, level should default to 'unranked' for comparison
+    taxon = Taxon()
+    assert taxon.rank_level == UNRANKED
 
 
 def test_taxon__taxonomy():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -351,8 +351,8 @@ def test_identification__empty():
 def test_identification__str():
     identification = ID.from_json(j_identification_3)
     assert str(identification) == (
-        'Identification(id=126501311, username=samroom, taxon_name=Species: '
-        'Danaus plexippus (Monarch), created_at=Aug 27, 2020, truncated_body=)'
+        'Identification(id=126501311, username=samroom, taxon_name=Danaus plexippus (Monarch), '
+        'created_at=Aug 27, 2020, truncated_body=)'
     )
 
 
@@ -827,10 +827,7 @@ def test_taxon__str():
         preferred_common_name='rathke’s woodlouse',
         rank='species',
     )
-    assert (
-        str(taxon_5)
-        == 'Taxon(id=137338523, full_name=Species Trachelipus rathkii (Rathke’s Woodlouse))'
-    )
+    assert str(taxon_5) == 'Taxon(id=137338523, full_name=Trachelipus rathkii (Rathke’s Woodlouse))'
 
     # Hyphens and parentheses in common name
     taxon_6 = Taxon(
@@ -840,7 +837,7 @@ def test_taxon__str():
         rank='ssp',
     )
     assert str(taxon_6) == (
-        'Taxon(id=642466, full_name=Subspecies Terpsiphone paradisi ceylonensis (Indian Paradise-Flycatcher (Sri Lanka)))'
+        'Taxon(id=642466, full_name=Terpsiphone paradisi ceylonensis (Indian Paradise-Flycatcher (Sri Lanka)))'
     )
 
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -798,28 +798,44 @@ def test_taxon__empty():
 
 
 def test_taxon__str():
-    taxon_0 = Taxon(
+    # Rank, name, and common name
+    taxon_1 = Taxon(id=3, name='Aves', preferred_common_name='birb', rank='class')
+    assert str(taxon_1) == 'Taxon(id=3, full_name=Class Aves (Birb))'
+
+    # Rank and name
+    taxon_2 = Taxon(id=3, name='Aves', rank='class')
+    assert str(taxon_2) == 'Taxon(id=3, full_name=Class Aves)'
+
+    # Name only
+    taxon_3 = Taxon(id=3, name='Aves')
+    assert str(taxon_3) == 'Taxon(id=3, full_name=Aves)'
+
+    # ID only
+    taxon_4 = Taxon(id=12345)
+    assert str(taxon_4) == 'Taxon(id=12345, full_name=12345)'
+
+    # Apostrophe in common name
+    taxon_5 = Taxon(
         id=137338523,
         name='Trachelipus rathkii',
         preferred_common_name='rathke’s woodlouse',
         rank='species',
     )
     assert (
-        str(taxon_0)
-        == 'Taxon(id=137338523, full_name=Species: Trachelipus rathkii (Rathke’s Woodlouse))'
+        str(taxon_5)
+        == 'Taxon(id=137338523, full_name=Species Trachelipus rathkii (Rathke’s Woodlouse))'
     )
 
-    taxon_1 = Taxon(id=3, name='Aves', preferred_common_name='birb', rank='class')
-    assert str(taxon_1) == 'Taxon(id=3, full_name=Class: Aves (Birb))'
-
-    taxon_2 = Taxon(id=3, name='Aves', rank='class')
-    assert str(taxon_2) == 'Taxon(id=3, full_name=Class: Aves)'
-
-    taxon_3 = Taxon(id=3, name='Aves')
-    assert str(taxon_3) == 'Taxon(id=3, full_name=Aves)'
-
-    taxon_4 = Taxon(id=0)
-    assert str(taxon_4) == 'Taxon(id=0, full_name=unknown taxon)'
+    # Hyphens and parentheses in common name
+    taxon_6 = Taxon(
+        id=642466,
+        name='Terpsiphone paradisi ceylonensis',
+        preferred_common_name='Indian paradise-flycatcher (sri lanka)',
+        rank='ssp',
+    )
+    assert str(taxon_6) == (
+        'Taxon(id=642466, full_name=Subspecies Terpsiphone paradisi ceylonensis (Indian Paradise-Flycatcher (Sri Lanka)))'
+    )
 
 
 def test_taxon__ancestors_children():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1101,10 +1101,18 @@ def test_make_tree__filtered():
 def test_make_tree__flattened():
     flat_list = make_tree(Taxon.from_json_list(j_life_list_1)).flatten()
     assert [t.id for t in flat_list] == [48460, 1, 2, 3, 573, 574, 889, 890, 980, 981]
+    assert [t.indent_level for t in flat_list] == [0, 1, 2, 3, 4, 5, 6, 7, 6, 7]
 
     assert flat_list[0].ancestors == []
     assert [t.id for t in flat_list[5].ancestors] == [48460, 1, 2, 3, 573]
     assert [t.id for t in flat_list[9].ancestors] == [48460, 1, 2, 3, 573, 574, 980]
+
+
+def test_make_tree__flattened_without_root():
+    taxa = Taxon.from_json_list(j_life_list_1)
+    flat_list = make_tree(taxa).flatten(hide_root=True)
+    assert [t.id for t in flat_list] == [1, 2, 3, 573, 574, 889, 890, 980, 981]
+    assert [t.indent_level for t in flat_list] == [0, 1, 2, 3, 4, 5, 6, 5, 6]
 
 
 def test_make_tree__flattened_filtered():
@@ -1123,11 +1131,10 @@ def test_make_tree__flattened_filtered():
         415027,
         538902,
     ]
+    assert [t.indent_level for t in flat_list] == [0, 1, 2, 3, 4, 4, 4, 4, 4]
 
     assert flat_list[0].ancestors == []
     assert [t.id for t in flat_list[1].ancestors] == [1]
-
-    assert [t.indent_level for t in flat_list] == [0, 1, 2, 3, 4, 4, 4, 4, 4]
 
 
 def test_make_tree__find_root():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -941,6 +941,12 @@ def test_taxon__no_default_photo(taxon_id):
     assert photo.url is not None
 
 
+def test_taxon__normalize_rank():
+    taxon = Taxon(rank='spp')
+    assert taxon.rank == 'species'
+    assert taxon.rank_level == 10
+
+
 def test_taxon__taxonomy():
     taxon = Taxon.from_json(j_taxon_1)
     assert taxon.taxonomy == {

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1102,12 +1102,36 @@ def test_make_tree__invalid():
 
 
 def test_make_tree__flattened():
-    flat_list = make_tree(Taxon.from_json_list(j_life_list_1)).flatten()
+    flat_list = make_tree(Taxon.from_json_list(j_life_list_2)).flatten()
     assert [t.id for t in flat_list] == [48460, 1, 2, 3, 573, 574, 889, 890, 980, 981]
 
     assert flat_list[0].ancestors == []
     assert [t.id for t in flat_list[5].ancestors] == [48460, 1, 2, 3, 573]
     assert [t.id for t in flat_list[9].ancestors] == [48460, 1, 2, 3, 573, 574, 980]
+
+
+def test_make_tree__flattened_filtered():
+    flat_list = make_tree(
+        Taxon.from_json_list(j_life_list_2),
+        include_ranks=['kingdom', 'phylum', 'family', 'genus', 'subgenus'],
+    ).flatten()
+    assert [t.id for t in flat_list] == [
+        48460,
+        1,
+        47120,
+        47221,
+        52775,
+        538903,
+        538893,
+        538900,
+        415027,
+        538902,
+    ]
+
+    assert flat_list[0].ancestors == []
+    assert [t.id for t in flat_list[2].ancestors] == [48460, 1]
+
+    assert [t.indent_level for t in flat_list] == [0, 1, 2, 3, 4, 5, 5, 5, 5, 5]
 
 
 # Users

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -387,6 +387,43 @@ def test_life_list__get_count():
     assert life_list.get_count(9999999) == 0  # Unobserved taxon
 
 
+def test_life_list__tree():
+    life_list = LifeList.from_json(j_life_list_2)
+    root = life_list.tree()
+
+    # Spot check the first few levels
+    assert root.name == 'Life'
+    assert root.children[0].name == 'Animalia'
+    assert root.children[0].children[0].name == 'Arthropoda'
+
+    # Ensure correct child sort order
+    node = root
+    for _ in range(14):
+        node = node.children[0]
+    assert node.name == 'Bombus'
+
+    children = [t.name for t in node.children]
+    assert children == ['Bombus', 'Psithyrus', 'Pyrobombus', 'Subterraneobombus', 'Thoracobombus']
+
+
+def test_life_list__invalid_tree():
+    """Attempting to make a tree with no common root taxon should raise an error"""
+    life_list = LifeList.from_json([j_observation_1, j_observation_2])
+
+    with pytest.raises(ValueError):
+        life_list.tree()
+
+
+def test_life_list__flatten_tree():
+    life_list = LifeList.from_json(j_life_list_1)
+    flat_list = life_list.tree().flatten()
+    assert [t.id for t in flat_list] == [48460, 1, 2, 3, 573, 574, 889, 890, 980, 981]
+
+    assert flat_list[0].ancestors == []
+    assert [t.id for t in flat_list[5].ancestors] == [48460, 1, 2, 3, 573]
+    assert [t.id for t in flat_list[9].ancestors] == [48460, 1, 2, 3, 573, 574, 980]
+
+
 # Messages
 # --------------------
 


### PR DESCRIPTION
Updates #499

Formatting:
- Omit rank in `Taxon.full_name` for species and below (to be more consistent with iNat's formatting)
- Fix common name title casing with apostrophes, parentheses, and dashes
- Add separate `Taxon.rich_full_name` property to use with terminal output
    - Italicize only for genus and below
    - Use for table output with `pprint()`

Ranks:
- Normalize `Taxon.rank` (casing, abbreviations, and other variations)
- Set `Taxon.rank_level` if rank name exists but level doesn't (for consistent rank sorting/comparison)
- Default `Taxon.rank_level` to 90 (unranked) if neither rank name or level is available
- Update `constants.COMMON_RANKS` to only include the main 7

Trees:
- Update `Taxon.ancestors` in `make_tree()`
- Add optional rank filtering to `make_tree()`
- Handle tree roots other than "Life" in `make_tree()`
- Handle ungrafted taxa and multiple roots in `make_tree()` by inserting "Life" as root node
- Remove `LifeList.tree()` in favor of `make_tree()`
    - This can be used with `LifeList` or a list of `Taxon` objects
- Add `hide_root` option to Taxon.flatten() to exclude the root from the list and from indentation level