### PR TITLE
Fix KeyError when using create_observation() in dry-run mode

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * ⚠️ Drop support for python 3.7
+* Fix `KeyError` when using `create_observation()` in dry-run mode
 
 ## 0.19.0 (2023-12-12)
 

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -12,11 +12,11 @@ from pyinaturalist.constants import CACHE_EXPIRATION
 from pyinaturalist.session import (
     CACHE_FILE,
     ClientSession,
+    MockResponse,
     clear_cache,
     delete,
     get,
     get_local_session,
-    get_mock_response,
     get_refresh_params,
     post,
     put,
@@ -105,6 +105,10 @@ def test_request_dry_run(
     else:
         assert response.reason == 'DRY_RUN'
         assert mock_send.call_count == 0
+
+        json_content = response.json()
+        assert len(json_content['results']) == json_content['total_results'] == 0
+        assert response.json()['arbitrary_key'] == ''
 
 
 @patch.object(Session, 'send')
@@ -207,7 +211,7 @@ def test_session__send__cache_settings(mock_send):
     session = ClientSession()
     with patch.object(session, 'send') as mock_cache_send:
         request = Request(method='GET', url='http://test.com').prepare()
-        mock_send.return_value = get_mock_response(request)
+        mock_send.return_value = MockResponse(request)
 
         session.send(request)
         mock_cache_send.assert_called_with(request)

--- a/test/v1/test_observations.py
+++ b/test/v1/test_observations.py
@@ -5,11 +5,10 @@ from unittest.mock import patch
 
 import pytest
 from dateutil.tz import tzoffset, tzutc
-from requests import PreparedRequest
 
 from pyinaturalist.constants import API_V1
 from pyinaturalist.exceptions import ObservationNotFound
-from pyinaturalist.session import ClientSession, get_mock_response
+from pyinaturalist.session import ClientSession, MockResponse
 from pyinaturalist.v1 import (
     create_observation,
     delete_observation,
@@ -32,8 +31,6 @@ from test.sample_data import (
     j_taxon_summary_1_conserved,
     j_taxon_summary_2_listed,
 )
-
-MOCK_RESPONSE = get_mock_response(PreparedRequest())
 
 
 def test_get_observation(requests_mock):
@@ -106,14 +103,14 @@ def test_get_observations__all_pages(requests_mock):
     assert len(observations['results']) == 2
 
 
-@patch.object(ClientSession, 'send', return_value=MOCK_RESPONSE)
+@patch.object(ClientSession, 'send', return_value=MockResponse())
 def test_get_observations__by_obs_field(mock_send):
     get_observations(taxon_id=3, observation_fields=['Species count'])
     request = mock_send.call_args[0][0]
     assert request.params == {'taxon_id': '3', 'field:Species count': ''}
 
 
-@patch.object(ClientSession, 'send', return_value=MOCK_RESPONSE)
+@patch.object(ClientSession, 'send', return_value=MockResponse())
 def test_get_observations__by_obs_field_values(mock_send):
     get_observations(taxon_id=3, observation_fields={'Species count': 2})
     request = mock_send.call_args[0][0]

--- a/test/v2/test_observations_v2.py
+++ b/test/v2/test_observations_v2.py
@@ -2,14 +2,11 @@ import json
 from unittest.mock import patch
 
 import pytest
-from requests import PreparedRequest
 
 from pyinaturalist.constants import API_V2
-from pyinaturalist.session import ClientSession, get_mock_response
+from pyinaturalist.session import ClientSession, MockResponse
 from pyinaturalist.v2 import get_observations
 from test.sample_data import SAMPLE_DATA
-
-MOCK_RESPONSE = get_mock_response(PreparedRequest())
 
 
 def test_get_observations__minimal(requests_mock):
@@ -91,14 +88,14 @@ def test_get_observations__all_pages__post(requests_mock):
     assert len(observations['results']) == 2
 
 
-@patch.object(ClientSession, 'send', return_value=MOCK_RESPONSE)
+@patch.object(ClientSession, 'send', return_value=MockResponse())
 def test_get_observations__by_obs_field(mock_send):
     get_observations(taxon_id=3, observation_fields=['Species count'])
     request = mock_send.call_args[0][0]
     assert request.params == {'taxon_id': '3', 'field:Species count': ''}
 
 
-@patch.object(ClientSession, 'send', return_value=MOCK_RESPONSE)
+@patch.object(ClientSession, 'send', return_value=MockResponse())
 def test_get_observations__by_obs_field_values(mock_send):
     get_observations(taxon_id=3, observation_fields={'Species count': 2})
     request = mock_send.call_args[0][0]


### PR DESCRIPTION
Plus some other improvements for mock responses. Fixes #536.