### PR TITLE
Update users.py

### DIFF
--- a/pyinaturalist/v1/users.py
+++ b/pyinaturalist/v1/users.py
@@ -51,7 +51,7 @@ def get_users_autocomplete(q: str, **params) -> JsonResponse:
     * Pagination is supported; default page size is 6, and max is 100.
 
     Example:
-        >>> response = get_taxa_autocomplete(q='my_userna')
+        >>> response = get_users_autocomplete(q='my_userna')
         >>> pprint(response)
         [1234] my_username
         [12345] my_username_2


### PR DESCRIPTION
Typo in docstring. Code example for 'get_users_autocomplete' erroneously uses 'get_taxa_autocomplete', presumably a copy/paste error.

