### PR TITLE
Add root_id filter to taxon.make_tree()

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@
 
 ### Models
 * Add `User.annotated_observations_count` field
+* Add `root_id` filter to `taxon.make_tree()` to explicitly set the root taxon instead of determining it automatically
 
 ### Rate limits, timeouts, and error handling
 * Increase default request timeout from 10 to 20 seconds

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1240,6 +1240,33 @@ def test_make_tree__ungrafted():
     assert root.children[1].name == 'Monocots'
 
 
+def test_make_tree__explicit_root():
+    """If a root taxon is provided, it should be used as the root node if possible"""
+    taxa = Taxon.from_json_list(j_life_list_2)
+    root = make_tree(taxa, root_id=1)
+    assert root.id == 1
+    assert len(root.children) == 1
+    assert root.children[0].name == 'Arthropoda'
+
+
+def test_make_tree__explicit_root_not_found():
+    """If a root taxon is provided but not included in the list, fall back to default behavior"""
+    taxa = Taxon.from_json_list(j_life_list_2)
+    root = make_tree(taxa, root_id=12345)
+    assert root.id == ROOT_TAXON_ID
+    assert len(root.children) == 1
+
+
+def test_make_tree__explicit_root_filtered_out():
+    """If a root taxon is provided but filtered out, find the next root matching the filter"""
+    taxa = Taxon.from_json_list(j_life_list_2)
+    root = make_tree(taxa, root_id=1, include_ranks=['family', 'genus', 'species'])
+    assert root.id == 47221
+    assert root.name == 'Apidae'
+    assert root.rank == 'family'
+    assert len(root.children) == 1
+
+
 # Users
 # --------------------
 


### PR DESCRIPTION
Adding this to simplify usage in dronefly, in the case where both root taxon and rank filters are provided, but the root taxon is filtered out.