### PR TITLE
Make rate-limiter specific to `/projects/{id}` configurable via session settings

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+## Unreleased
+* `ClientSession` arguments `ratelimit_path` and `lock_path` will now apply to the separate rate-limiter used for `/projects/{id}`
+
 ## 0.20.1 (2025-01-18)
 * Fix `AttributeError` when initializing `Observation.taxon` with a `Taxon` object
 

--- a/docs/user_guide/advanced.md
+++ b/docs/user_guide/advanced.md
@@ -90,6 +90,11 @@ Float values also work, for example to slow it down to less than 1 request per s
 >>> session = ClientSession(per_second=0.5)
 ```
 
+Some persistent rate-limiting state is stored on-disk. To change the default path for this:
+```python
+>>> session = ClientSession(ratelimit_path='/tmp/ratelimit.db')
+```
+
 ### Distributed Application Rate Limiting
 The default rate-limiting backend is thread-safe, and persistent across application restarts. If
 you have a larger application running from multiple processes, you will need an additional locking
@@ -104,6 +109,11 @@ mechanism to make sure these processes don't conflict with each other. This is a
 This requires installing one additional dependency, [py-filelock](https://github.com/tox-dev/py-filelock):
 ```bash
 pip install filelock
+```
+
+To change the default path used for the file lock:
+```python
+>>> session = ClientSession(bucket_class=FileLockSQLiteBucket, lock_path='/tmp/ratelimit.lock')
 ```
 
 ## Logging

--- a/pyinaturalist/constants.py
+++ b/pyinaturalist/constants.py
@@ -6,7 +6,6 @@ from typing import IO, TYPE_CHECKING, Any, BinaryIO, Dict, Iterable, List, Optio
 
 from dateutil.relativedelta import relativedelta
 from platformdirs import user_data_dir
-from pyrate_limiter.sqlite_bucket import LOCK_PATH as DEFAULT_LOCK_PATH
 
 # iNaturalist URLs
 API_V0 = 'https://www.inaturalist.org'
@@ -66,6 +65,7 @@ CACHE_EXPIRATION = {
 }
 CACHE_FILE = join(DATA_DIR, 'api_requests.db')
 RATELIMIT_FILE = join(DATA_DIR, 'api_ratelimit.db')
+DEFAULT_LOCK_PATH = join(DATA_DIR, 'api_ratelimit.lock')
 
 # Response formats supported by v0 GET /observations endpoint
 OBSERVATION_FORMATS = ['atom', 'csv', 'dwc', 'json', 'kml', 'widget']

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -18,7 +18,6 @@ from pyinaturalist.session import (
     delete,
     get,
     get_local_session,
-    get_refresh_params,
     post,
     put,
 )
@@ -253,11 +252,12 @@ def test_filelock(mock_send, tmp_path):
         assert bucket._lock.lock_file == lock_path
 
 
-@patch('pyinaturalist.session.REFRESH_LIMITER', Limiter(RequestRate(1, 2)))
 def test_get_refresh_params():
-    assert get_refresh_params('test') == {'refresh': True}
-    assert get_refresh_params('test2') == {'refresh': True}
-    assert get_refresh_params('test') == {'refresh': True, 'v': 1}
-    assert get_refresh_params('test') == {'refresh': True, 'v': 2}
+    session = ClientSession()
+    session.refresh_limiter = Limiter(RequestRate(1, 2))
+    assert session.get_refresh_params('test') == {'refresh': True}
+    assert session.get_refresh_params('test2') == {'refresh': True}
+    assert session.get_refresh_params('test') == {'refresh': True, 'v': 1}
+    assert session.get_refresh_params('test') == {'refresh': True, 'v': 2}
     sleep(2)
-    assert get_refresh_params('test') == {'refresh': True}
+    assert session.get_refresh_params('test') == {'refresh': True}


### PR DESCRIPTION
Fixes #610 

`ClientSession` arguments `ratelimit_path` and `lock_path` will now apply to the separate rate-limiter used for `/projects/{id}`:
```py
from pyinaturalist import ClientSession
session = ClientSession(ratelimit_path='/tmp/ratelimit.db', lock_path='/tmp/ratelimit.lock')
```

Or via `iNatClient`:
```py
from pyinaturalist import  iNatClient
client= iNatClient(ratelimit_path='/tmp/ratelimit.db', lock_path='/tmp/ratelimit.lock')
```