### PR TITLE
Fix list slicing on custom collection types

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Fix corner case resulting in `observed_on` not being converted to `datetime`
+* Fix list slicing on custom collection types (`TaxonCounts`, etc.)
 * Add an `Observation.formatted_location` property
 
 ## 0.21.1 (2026-02-13)

--- a/pyinaturalist/models/base.py
+++ b/pyinaturalist/models/base.py
@@ -237,6 +237,17 @@ class BaseModelCollection(BaseModel, UserList, Generic[T]):  # type: ignore [mis
         """
         return getattr(self.id_map.get(id), count_field, 0)
 
+    def __getitem__(self, index):
+        result = self.data[index]
+        # When getting a slice, skip converters and directly copy data
+        if isinstance(index, slice):
+            new_obj = object.__new__(self.__class__)
+            vars(new_obj).update(vars(self))
+            object.__setattr__(new_obj, 'data', result)
+            object.__setattr__(new_obj, '_id_map', None)
+            return new_obj
+        return result
+
     def __str__(self) -> str:
         return '\n'.join([str(obj) for obj in self.data])
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -1190,6 +1190,14 @@ def test_taxon_counts__empty():
     assert taxon_counts.id_map == {}
 
 
+def test_taxon_counts__slice():
+    taxon_counts = TaxonCounts.from_json(j_obs_species_counts)
+    sliced = taxon_counts[:3]
+    assert len(sliced) == 3
+    assert isinstance(sliced, TaxonCounts)
+    assert all(isinstance(item, TaxonCount) for item in sliced)
+
+
 def test_taxon_summary():
     ts = TaxonSummary.from_json(j_taxon_summary_2_listed)
     assert ts.listed_taxon.taxon_id == 47219


### PR DESCRIPTION
Fixes errors like:
```py
Traceback (most recent call last):
  File "test_counts.py", line 6, in <module>
    pprint(taxa[:20])
    ~~~~~~^^^^^^^^^^^
  File "pyinaturalist/formatters.py", line 167, in pprint
    print(format_table(values))
          ~~~~~~~~~~~~^^^^^^^^
  File "pyinaturalist/formatters.py", line 221, in format_table
    values = ensure_model_list(values)
  File "pyinaturalist/formatters.py", line 205, in ensure_model_list
    if isinstance(values, BaseModelCollection) or isinstance(values[0], BaseModel):
                                                             ~~~~~~^^^
IndexError: list index out of range
```