### PR TITLE
Add ObservationFieldController for iNatClient

### DIFF
--- a/pyinaturalist/client.py
+++ b/pyinaturalist/client.py
@@ -13,6 +13,7 @@ from pyinaturalist.controllers import (
     AnnotationController,
     IdentificationController,
     ObservationController,
+    ObservationFieldController,
     PlaceController,
     ProjectController,
     SearchController,
@@ -41,6 +42,7 @@ class iNatClient:
     * :fa:`tag` :py:class:`annotations <.AnnotationController>`
     * :fa:`fingerprint` :py:class:`identifications <.IdentificationController>`
     * :fa:`binoculars` :py:class:`observations <.ObservationController>`
+    * :fa:`tag` :py:class:`observation_fields <.ObservationFieldController>`
     * :fa:`location-dot` :py:class:`places <.PlaceController>`
     * :fa:`users` :py:class:`projects <.ProjectController>`
     * :fa:`search` :py:class:`search <.SearchController>`
@@ -85,6 +87,9 @@ class iNatClient:
         self.observations = ObservationController(
             self
         )  #: Interface for :py:class:`observation requests <.ObservationController>`
+        self.observation_fields = ObservationFieldController(
+            self
+        )  #: Interface for :py:class:`observation field requests <.ObservationFieldController>`
         self.places = PlaceController(
             self
         )  #: Interface for :py:class:`place requests <.PlaceController>`

--- a/pyinaturalist/controllers/__init__.py
+++ b/pyinaturalist/controllers/__init__.py
@@ -8,6 +8,7 @@ from pyinaturalist.controllers.base_controller import BaseController
 from pyinaturalist.controllers.annotation_controller import AnnotationController
 from pyinaturalist.controllers.identification_controller import IdentificationController
 from pyinaturalist.controllers.observation_controller import ObservationController
+from pyinaturalist.controllers.observation_field_controller import ObservationFieldController
 from pyinaturalist.controllers.place_controller import PlaceController
 from pyinaturalist.controllers.project_controller import ProjectController
 from pyinaturalist.controllers.taxon_controller import TaxonController

--- a/pyinaturalist/controllers/observation_field_controller.py
+++ b/pyinaturalist/controllers/observation_field_controller.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+from pyinaturalist.constants import IntOrStr, JsonResponse
+from pyinaturalist.controllers import BaseController
+from pyinaturalist.models import ObservationField
+from pyinaturalist.v0 import get_observation_fields
+from pyinaturalist.v1 import delete_observation_field, set_observation_field
+
+
+class ObservationFieldController(BaseController):
+    """:fa:`tag` Controller for ObservationField and ObservationFieldValue requests"""
+
+    def search(self, q: str | None = None, **params) -> list[ObservationField]:
+        """Search observation fields by name.
+
+        .. rubric:: Notes
+
+        * API reference: :v0:`GET /observation_fields <get-observation_fields>`
+        * This uses the v0 API endpoint, which does not support ``per_page``
+
+        Example:
+            >>> fields = client.observation_fields.search('vespawatch_id')
+            >>> pprint(fields)
+             ID     Type   Name             Description
+             ...
+
+        Args:
+            q: Search query for observation field name
+        """
+        response = self.client.request(get_observation_fields, q=q, **params)
+        return ObservationField.from_json_list(response['results'])
+
+    def set(
+        self,
+        observation_id: int,
+        observation_field_id: int,
+        value: Any,
+        **params,
+    ) -> JsonResponse:
+        """Create or update an observation field value on an observation.
+
+        .. rubric:: Notes
+
+        * :fa:`lock` :ref:`Requires authentication <auth>`
+        * API reference: :v1:`POST /observation_field_values <post_observation_field_values>`
+        * To find an ``observation_field_id``, use :py:meth:`search` or
+          `search on iNaturalist <https://www.inaturalist.org/observation_fields>`_
+
+        Example:
+            First find an observation field by name, if the ID is unknown:
+
+            >>> fields = client.observation_fields.search('vespawatch_id')
+            >>> field_id = fields[0].id
+
+            Then set the value on an observation:
+
+            >>> client.observation_fields.set(
+            ...     observation_id=7345179,
+            ...     observation_field_id=field_id,
+            ...     value=250,
+            ... )
+
+        Args:
+            observation_id: ID of the observation receiving this observation field value
+            observation_field_id: ID of the observation field for this observation field value
+            value: Value for the observation field
+
+        Returns:
+            The newly created or updated observation field value record
+        """
+        return self.client.request(
+            set_observation_field,
+            auth=True,
+            observation_id=observation_id,
+            observation_field_id=observation_field_id,
+            value=value,
+            **params,
+        )
+
+    def delete(self, observation_field_value_id: IntOrStr, **params):
+        """Delete an observation field value from an observation.
+
+        .. rubric:: Notes
+
+        * :fa:`lock` :ref:`Requires authentication <auth>`
+        * API reference: :v1:`DELETE /observation_field_values/{id} <delete_observation_field_values_id>`
+
+        Example:
+            Observation field value IDs can be found on observation records:
+
+            >>> obs = client.observations(70963477)
+            >>> for ofv in obs.ofvs:
+            ...     client.observation_fields.delete(ofv.id)
+
+        Args:
+            observation_field_value_id: ID or UUID of the observation field value to delete
+        """
+        self.client.request(
+            delete_observation_field,
+            auth=True,
+            observation_field_value_id=observation_field_value_id,
+            **params,
+        )

--- a/test/controllers/test_observation_field_controller.py
+++ b/test/controllers/test_observation_field_controller.py
@@ -1,0 +1,55 @@
+from pyinaturalist.client import iNatClient
+from pyinaturalist.constants import API_V0, API_V1
+from pyinaturalist.models import ObservationField
+from test.sample_data import SAMPLE_DATA
+
+
+def test_search(requests_mock):
+    requests_mock.get(
+        f'{API_V0}/observation_fields.json',
+        json=SAMPLE_DATA['get_observation_fields_page1'],
+        status_code=200,
+    )
+    fields = iNatClient().observation_fields.search(q='sex')
+    assert len(fields) == 30
+    assert isinstance(fields[0], ObservationField)
+    assert fields[0].id == 4813
+    assert fields[0].name == 'Sex (deer/turkey)'
+    assert fields[0].datatype == 'text'
+
+
+def test_search__no_query(requests_mock):
+    requests_mock.get(
+        f'{API_V0}/observation_fields.json',
+        json=SAMPLE_DATA['get_observation_fields_page1'],
+        status_code=200,
+    )
+    fields = iNatClient().observation_fields.search()
+    assert len(fields) == 30
+
+
+def test_set(requests_mock):
+    requests_mock.post(
+        f'{API_V1}/observation_field_values',
+        json=SAMPLE_DATA['post_put_observation_field_value'],
+        status_code=200,
+    )
+    response = iNatClient().observation_fields.set(
+        observation_id=18166477,
+        observation_field_id=31,
+        value='fouraging',
+        access_token='token',
+    )
+    assert response['id'] == 31
+    assert response['observation_field_id'] == 31
+    assert response['observation_id'] == 18166477
+    assert response['value'] == 'fouraging'
+
+
+def test_delete(requests_mock):
+    requests_mock.delete(
+        f'{API_V1}/observation_field_values/1234',
+        json={'errors': []},
+        status_code=200,
+    )
+    iNatClient().observation_fields.delete(1234, access_token='token')


### PR DESCRIPTION
## Summary

Implements #265 by adding an `ObservationFieldController` class that provides an object-oriented interface for observation field operations through `iNatClient`.

**New methods on `client.observation_fields`:**

- **`search(q=...)`** - Search observation fields by name. Wraps the v0 `GET /observation_fields` endpoint and returns `ObservationField` model objects.
- **`set(observation_id, observation_field_id, value)`** - Create or update an observation field value on an observation. Wraps the v1 `POST /observation_field_values` endpoint. Requires authentication.
- **`delete(observation_field_value_id)`** - Delete an observation field value from an observation. Wraps the v1 `DELETE /observation_field_values/{id}` endpoint. Requires authentication.

**Usage example:**

```python
from pyinaturalist import iNatClient

client = iNatClient()

# Search for observation fields by name
fields = client.observation_fields.search('vespawatch_id')

# Set an observation field value on an observation
client.observation_fields.set(
    observation_id=7345179,
    observation_field_id=fields[0].id,
    value=250,
)

# Delete an observation field value
client.observation_fields.delete(ofv_id)
```

**Files changed:**

- `pyinaturalist/controllers/observation_field_controller.py` - New controller with `search`, `set`, and `delete` methods
- `pyinaturalist/controllers/__init__.py` - Export new controller
- `pyinaturalist/client.py` - Register `observation_fields` attribute on `iNatClient`
- `test/controllers/test_observation_field_controller.py` - Tests for all three methods

**Design decisions:**

- Follows the same patterns as existing controllers (`AnnotationController`, `ProjectController`, etc.)
- `search()` returns `ObservationField` model objects for a typed experience
- `set()` returns the raw JSON response dict because the v0/v1 API response format (`observation_field_id`) doesn't map cleanly to the `ObservationFieldValue` model (which uses `field_id` from the v1 observation response)
- `delete()` returns nothing, consistent with `AnnotationController.delete()`

## Test plan

- [x] All 4 new tests pass (`test_search`, `test_search__no_query`, `test_set`, `test_delete`)
- [x] All 54 existing controller tests still pass
- [x] Full test suite (634 tests) passes with no regressions