### PR TITLE
fix(users): disable cache by default for get_current_user

### DIFF
--- a/pyinaturalist/v1/users.py
+++ b/pyinaturalist/v1/users.py
@@ -1,5 +1,7 @@
 from logging import getLogger
 
+from requests_cache import DO_NOT_CACHE
+
 from pyinaturalist.constants import API_V1, IntOrStr, JsonResponse
 from pyinaturalist.converters import convert_all_timestamps, convert_generic_timestamps
 from pyinaturalist.docs import document_request_params
@@ -77,6 +79,7 @@ def get_current_user(access_token: str | None = None, **params) -> JsonResponse:
 
     * :fa:`lock` :ref:`Requires authentication <auth>`
     * API reference: :v1:`GET /users/me <Users/get_users_me>`
+    * Disables request caching by default, since responses are user-specific
 
 
     Example:
@@ -87,5 +90,7 @@ def get_current_user(access_token: str | None = None, **params) -> JsonResponse:
     Returns:
         Response dict containing a single user record
     """
+    params.setdefault('force_refresh', True)
+    params.setdefault('expire_after', DO_NOT_CACHE)
     response = get(f'{API_V1}/users/me', access_token=access_token, **params)
     return convert_generic_timestamps(response.json()['results'][0])

--- a/test/v1/test_users.py
+++ b/test/v1/test_users.py
@@ -1,9 +1,11 @@
 from datetime import datetime
 
 from dateutil.tz import tzutc
+from requests_cache import DO_NOT_CACHE
 
 from pyinaturalist.constants import API_V1
 from pyinaturalist.v1 import get_current_user, get_user_by_id, get_users_autocomplete
+from pyinaturalist.v1 import users as users_module
 from test.sample_data import SAMPLE_DATA
 
 
@@ -48,3 +50,43 @@ def test_get_current_user(requests_mock):
     assert user['id'] == 886482
     assert user['login'] == 'niconoe'
     assert user['created_at'] == datetime(2018, 4, 23, 17, 11, 14, tzinfo=tzutc())
+
+
+def test_get_current_user__disables_cache_by_default(monkeypatch):
+    captured_kwargs = {}
+
+    def mock_get(*_, **kwargs):
+        captured_kwargs.update(kwargs)
+
+        class _Response:
+            @staticmethod
+            def json():
+                return SAMPLE_DATA['get_users_autocomplete']
+
+        return _Response()
+
+    monkeypatch.setattr(users_module, 'get', mock_get)
+    users_module.get_current_user(access_token='test-token')
+
+    assert captured_kwargs['force_refresh'] is True
+    assert captured_kwargs['expire_after'] == DO_NOT_CACHE
+
+
+def test_get_current_user__cache_settings_can_be_overridden(monkeypatch):
+    captured_kwargs = {}
+
+    def mock_get(*_, **kwargs):
+        captured_kwargs.update(kwargs)
+
+        class _Response:
+            @staticmethod
+            def json():
+                return SAMPLE_DATA['get_users_autocomplete']
+
+        return _Response()
+
+    monkeypatch.setattr(users_module, 'get', mock_get)
+    users_module.get_current_user(force_refresh=False, expire_after=300)
+
+    assert captured_kwargs['force_refresh'] is False
+    assert captured_kwargs['expire_after'] == 300


### PR DESCRIPTION
## Summary
This updates `get_current_user()` to avoid shared cache collisions for multi-user/authenticated usage.

### What changed
- `get_current_user()` now defaults to:
  - `force_refresh=True`
  - `expire_after=DO_NOT_CACHE`
- Callers can still explicitly override those values via kwargs.
- Added tests to verify both the new default behavior and override behavior.

## Why
`/users/me` responses are user-specific and can be incorrect when request matching ignores auth token values. This endpoint is a good candidate to bypass cache by default.

Fixes #654

## Validation
- `uv run pytest -q test/v1/test_users.py`
- `uv run prek run --files pyinaturalist/v1/users.py test/v1/test_users.py`
