### PR TITLE
feat(annotations): support create() with term/value labels

### DIFF
--- a/pyinaturalist/controllers/annotation_controller.py
+++ b/pyinaturalist/controllers/annotation_controller.py
@@ -133,9 +133,9 @@ class AnnotationController(BaseController):
 
     def create(
         self,
+        resource_id: IntOrStr,
         controlled_attribute_id: int | None = None,
         controlled_value_id: int | None = None,
-        resource_id: IntOrStr | None = None,
         resource_type: str = 'Observation',
         term: str | None = None,
         value: str | None = None,
@@ -144,9 +144,9 @@ class AnnotationController(BaseController):
         """Create a new annotation on an observation.
 
         Args:
+            resource_id: Observation ID or UUID
             controlled_attribute_id: Annotation attribute ID
             controlled_value_id: Annotation value ID
-            resource_id: Observation ID or UUID
             resource_type: Resource type, if something other than an observation
             term: Annotation term label, used as an alternative to ``controlled_attribute_id``
             value: Annotation value label, used as an alternative to ``controlled_value_id``
@@ -154,22 +154,19 @@ class AnnotationController(BaseController):
         Example:
             Add a 'Plant phenology: Flowering' annotation to an observation (via IDs):
 
-            >>> client.annotations.create(12, 13, 164609837)
+            >>> client.annotations.create(
+            ...     164609837,
+            ...     controlled_attribute_id=12,
+            ...     controlled_value_id=13,
+            ... )
 
             Add the same annotation by label:
 
-            >>> client.annotations.create(
-            ...     term='Plant Phenology',
-            ...     value='Flowering',
-            ...     resource_id=164609837,
-            ... )
+            >>> client.annotations.create(164609837, term='Plant Phenology', value='Flowering')
 
         Returns:
             The newly created Annotation object
         """
-        if resource_id is None:
-            raise ValueError('Must specify resource_id')
-
         controlled_attribute_id, controlled_value_id = self._resolve_annotation_ids(
             controlled_attribute_id=controlled_attribute_id,
             controlled_value_id=controlled_value_id,

--- a/test/controllers/test_annotation_controller.py
+++ b/test/controllers/test_annotation_controller.py
@@ -78,9 +78,9 @@ def test_create(requests_mock):
 
     client = iNatClient()
     result = client.annotations.create(
+        164609837,
         controlled_attribute_id=12,
         controlled_value_id=13,
-        resource_id=164609837,
     )
     assert isinstance(result, Annotation)
 
@@ -105,9 +105,9 @@ def test_create__by_label(requests_mock):
 
     client = iNatClient()
     result = client.annotations.create(
+        164609837,
         term='Alive or Dead',
         value='Alive',
-        resource_id=164609837,
     )
     assert isinstance(result, Annotation)
 
@@ -119,11 +119,11 @@ def test_create__by_label(requests_mock):
 
 def test_create__missing_term_value_pair():
     with pytest.raises(ValueError, match='Must specify either'):
-        iNatClient().annotations.create(term='Alive or Dead', resource_id=164609837)
+        iNatClient().annotations.create(164609837, term='Alive or Dead')
 
 
 def test_create__missing_resource_id():
-    with pytest.raises(ValueError, match='Must specify resource_id'):
+    with pytest.raises(TypeError, match='resource_id'):
         iNatClient().annotations.create(term='Alive or Dead', value='Alive')
 
 
@@ -134,7 +134,7 @@ def test_create__invalid_term(requests_mock):
         status_code=200,
     )
     with pytest.raises(ValueError, match='Annotation term not found'):
-        iNatClient().annotations.create(term='Not a term', value='Alive', resource_id=164609837)
+        iNatClient().annotations.create(164609837, term='Not a term', value='Alive')
 
 
 def test_create__invalid_value_for_term(requests_mock):
@@ -145,9 +145,9 @@ def test_create__invalid_value_for_term(requests_mock):
     )
     with pytest.raises(ValueError, match='Annotation value not found for term'):
         iNatClient().annotations.create(
+            164609837,
             term='Alive or Dead',
             value='Not a value',
-            resource_id=164609837,
         )
 
 


### PR DESCRIPTION
## Summary
- Add support for creating annotations by term/value labels in `AnnotationController.create()`
- Keep existing ID-based behavior unchanged
- Add clear validation errors for missing/invalid term-value input

## Details
- `create()` now accepts either:
  - `controlled_attribute_id` + `controlled_value_id` (existing path), or
  - `term` + `value` (new path)
- Label input is normalized (`strip()` + case-insensitive match)
- Label-based input resolves to IDs using controlled terms from `GET /controlled_terms`

## Tests
Added/updated controller tests:
- `test_create__by_label`
- `test_create__missing_term_value_pair`
- `test_create__invalid_term`
- `test_create__invalid_value_for_term`

## Validation
- `uv tool run ruff check pyinaturalist/controllers/annotation_controller.py test/controllers/test_annotation_controller.py`
- `uv run pytest -q test/controllers/test_annotation_controller.py`

Closes #528
