### PR TITLE
Misc OAuth improvements/bugfixes

### DIFF
--- a/pyinaturalist/client/oauth.py
+++ b/pyinaturalist/client/oauth.py
@@ -10,7 +10,6 @@ from os import getenv
 from keyring import get_password, set_password
 from keyring.errors import KeyringError
 from requests import HTTPError, Response
-from requests.exceptions import RetryError
 
 from pyinaturalist.client.oauth_callback import (
     _build_token_payload,
@@ -41,7 +40,15 @@ def _decode_jwt_exp(token: str) -> datetime | None:
         payload = json.loads(base64.urlsafe_b64decode(payload_b64))
         exp = payload.get('exp')
         return datetime.fromtimestamp(exp, tz=timezone.utc) if exp else None
-    except (ValueError, KeyError, AttributeError, OverflowError, binascii.Error):
+    except (
+        ValueError,
+        KeyError,
+        AttributeError,
+        OverflowError,
+        OSError,
+        TypeError,
+        binascii.Error,
+    ):
         return None
 
 
@@ -98,6 +105,7 @@ def get_access_token(
 
     Raises:
         :py:exc:`requests.HTTPError`: (401) if credentials are invalid
+        :py:exc:`.AuthenticationError`: if required credentials are missing
     """
     session, cached = _get_cached_jwt(refresh)
     if cached:
@@ -122,7 +130,6 @@ def get_access_token(
 
     # Get OAuth access token
     response = session.post(f'{API_V0}/oauth/token', json=payload)
-    response.raise_for_status()
     access_token = response.json()['access_token']
 
     # If specified, use OAuth token to get (and cache) a JWT
@@ -236,7 +243,6 @@ def get_access_token_via_auth_code(
         app_id, auth_code, redirect_uri, code_verifier, app_secret, use_pkce
     )
     response = session.post(f'{API_V0}/oauth/token', json=payload)
-    response.raise_for_status()
     access_token = response.json()['access_token']
 
     # If specified, use OAuth token to get (and cache) a JWT

--- a/pyinaturalist/client/oauth.py
+++ b/pyinaturalist/client/oauth.py
@@ -264,13 +264,22 @@ def _get_cached_jwt(refresh: bool) -> tuple[ClientSession, str | None]:
 
 
 def validate_token(access_token: str) -> bool:
-    """Determine if an access token is valid"""
+    """Determine if an access token is valid.
+
+    Returns ``False`` when the server confirms the token is invalid (401);
+    other failures are not re-raised.
+
+    Raises:
+        :py:exc:`requests.HTTPError`: for any non-401 error response
+    """
     session = get_local_session()
     try:
         session.request('GET', f'{API_V1}/users/me', access_token=access_token)
         return True
-    except (HTTPError, RetryError):
-        return False
+    except HTTPError as e:
+        if e.response is not None and e.response.status_code == 401:
+            return False
+        raise
 
 
 def get_keyring_credentials() -> dict[str, str | None]:

--- a/pyinaturalist/client/oauth.py
+++ b/pyinaturalist/client/oauth.py
@@ -108,7 +108,7 @@ def get_access_token(
         :py:exc:`.AuthenticationError`: if required credentials are missing
     """
     session, cached = _get_cached_jwt(refresh)
-    if cached:
+    if cached and jwt:
         return cached
 
     # Otherwise check for credentials in either args or environment variables
@@ -213,7 +213,7 @@ def get_access_token_via_auth_code(
             authorize in time, or the token exchange fails.
     """
     session, cached = _get_cached_jwt(refresh)
-    if cached:
+    if cached and jwt:
         return cached
 
     app_id, app_secret = _resolve_auth_code_creds(app_id, app_secret, use_pkce)

--- a/test/client/test_oauth.py
+++ b/test/client/test_oauth.py
@@ -72,6 +72,20 @@ def test_get_access_token__cached_jwt(requests_mock):
     assert token_1 == token_2 == JWT_API_TOKEN
 
 
+@patch.dict(os.environ, {}, clear=True)
+@patch('pyinaturalist.client.oauth._get_jwt', return_value=JWT_RESPONSE_200)
+def test_get_access_token__jwt_false_ignores_cached_jwt(mock_get_jwt, requests_mock):
+    """jwt=False must not return a cached JWT, even if one is available."""
+    requests_mock.post(f'{API_V0}/oauth/token', json=token_accepted_json, status_code=200)
+
+    token = get_access_token(
+        'valid_username', 'valid_password', 'valid_app_id', 'valid_app_secret', jwt=False
+    )
+    assert token == OAUTH_ACCESS_TOKEN
+    # Only one _get_jwt call (the cache probe); no second call to fetch a JWT
+    mock_get_jwt.assert_called_once()
+
+
 @patch.dict(os.environ, MOCK_CREDS_ENV)
 @patch('pyinaturalist.client.oauth.get_keyring_credentials')
 @patch('pyinaturalist.client.oauth._get_jwt', side_effect=[NOT_CACHED_RESPONSE, JWT_RESPONSE_200])
@@ -284,6 +298,24 @@ def test_get_access_token_via_auth_code__cached_jwt(mock_get_jwt):
     """If a JWT is already cached, return it without starting the browser flow."""
     token = get_access_token_via_auth_code(app_id='valid_app_id')
     assert token == JWT_API_TOKEN
+
+
+@patch.dict(os.environ, {}, clear=True)
+@patch('pyinaturalist.client.oauth._get_jwt', return_value=JWT_RESPONSE_200)
+@patch(
+    'pyinaturalist.client.oauth_callback.get_auth_code_via_server',
+    return_value=_make_server_result('mock_auth_code'),
+)
+def test_get_access_token_via_auth_code__jwt_false_ignores_cached_jwt(
+    mock_server, mock_get_jwt, requests_mock
+):
+    """jwt=False must not return a cached JWT, even if one is available."""
+    requests_mock.post(f'{API_V0}/oauth/token', json=token_accepted_json, status_code=200)
+
+    token = get_access_token_via_auth_code(app_id='valid_app_id', jwt=False)
+    assert token == OAUTH_ACCESS_TOKEN
+    # Only one _get_jwt call (the cache probe); no second call to fetch a JWT
+    mock_get_jwt.assert_called_once()
 
 
 @patch.dict(os.environ, {}, clear=True)

--- a/test/client/test_oauth.py
+++ b/test/client/test_oauth.py
@@ -472,17 +472,28 @@ def test_get_access_token_via_auth_code__custom_get_code_oob(
 # --------------
 
 
-@pytest.mark.parametrize('response_code', [200, 401, 403, 502])
-def test_validate_token(response_code):
+@pytest.mark.parametrize('response_code, expected', [(200, True), (401, False)])
+def test_validate_token(response_code, expected):
     with patch.object(ClientSession, 'send', return_value=Response()) as mock_get:
         mock_get.return_value.status_code = response_code
-        assert validate_token('token') == (response_code == 200)
+        assert validate_token('token') is expected
 
 
-def test_validate_token__retry_error():
-    """RetryError (retries exhausted on a 5xx response) returns False, not an exception."""
+@pytest.mark.parametrize('response_code', [403, 502])
+def test_validate_token__other_http_error_propagates(response_code):
+    """Only a 401 is treated as 'invalid'; other HTTP errors are not swallowed."""
+    with patch.object(ClientSession, 'send', return_value=Response()) as mock_get:
+        mock_get.return_value.status_code = response_code
+        with pytest.raises(HTTPError):
+            validate_token('token')
+
+
+def test_validate_token__retry_error_propagates():
+    """RetryError (retries exhausted on a 5xx response) is not swallowed, since token
+    validity could not actually be determined."""
     with patch.object(ClientSession, 'send', side_effect=RetryError):
-        assert validate_token('token') is False
+        with pytest.raises(RetryError):
+            validate_token('token')
 
 
 # get_keyring_credentials
@@ -518,6 +529,8 @@ def test_set_keyring_credentials(set_password):
     [
         ({'exp': 1893456000}, 1893456000),  # valid exp claim
         ({}, None),  # no exp claim
+        ({'exp': 'not-a-number'}, None),  # non-numeric exp claim (TypeError)
+        ({'exp': 99999999999999999}, None),  # out-of-range exp claim (OSError)
     ],
 )
 def test_decode_jwt_exp(payload, expected_exp):


### PR DESCRIPTION
*Catch additional exception types when decoding JWTs
* Remove redundant raise_for_status() calls
* Fix returning JWT when one is cached but `jwt=False`
* Update `validate_token()` to re-raise non-401 errors instead of returning False